### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 
 ## Overview
 
-This adapter allows to use Luxon with the Chart.js.
+This adapter allows the use of Luxon with Chart.js.
 
 Requires [Chart.js](https://github.com/chartjs/Chart.js/releases) **2.8.0** or later and [Luxon](https://moment.github.io/luxon/) **1.0.0** or later.
+
+**Note:** once loaded, this adapter overrides the default date-adapter provided in Chart.js (as a side-effect).
 
 ## Installation
 
@@ -14,36 +16,25 @@ Requires [Chart.js](https://github.com/chartjs/Chart.js/releases) **2.8.0** or l
 
 ```
 npm install chartjs-adapter-luxon --save
+npm install luxon --save
+```
+
+```javascript
+import Chart from 'chart.js';
+import 'chartjs-adapter-luxon';
 ```
 
 ### CDN
 
 By default, `https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon` returns the latest (minified) version, however it's [highly recommended](https://www.jsdelivr.com/features) to always specify a version in order to avoid breaking changes. This can be achieved by appending `@{version}` to the URL:
 
-```
-https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@0.1.0
+```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/luxon@1.11.4/build/global/luxon.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@0.1.1"></script>
 ```
 
 Read more about jsDeliver versioning on their [website](http://www.jsdelivr.com/).
-
-## Integration
-
-**Note:** once loaded, this adapter overrides the default date-adapter provided in Chart.js (as a side-effect).
-
-### HTML
-
-```html
-<script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/luxon@1.8.2/build/global/luxon.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@0.1.0"></script>
-```
-
-### Module
-
-```javascript
-import Chart from 'chart.js';
-import 'chartjs-adapter-luxon';
-```
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Requires [Chart.js](https://github.com/chartjs/Chart.js/releases) **2.8.0** or l
 ### npm
 
 ```
-npm install chartjs-adapter-luxon --save
-npm install luxon --save
+npm install luxon chartjs-adapter-luxon --save
 ```
 
 ```javascript
@@ -34,7 +33,7 @@ By default, `https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon` returns the lat
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@0.1.1"></script>
 ```
 
-Read more about jsDeliver versioning on their [website](http://www.jsdelivr.com/).
+Read more about jsDelivr versioning on their [website](http://www.jsdelivr.com/).
 
 ## Configuration
 


### PR DESCRIPTION
- Combined the `installation` and `integration` sections. These sections had basically the same content for loading from a script tag. It's also more coherent for the npm version to put the content together vs refering to two separate sections
- Show that `luxon` has to be installed separately and is not pulled in as a dependency
- Update the version number on the readme to 0.1.1
- Removed `/dist/Chart.min.js` from Chart.js CDN link. Sent https://github.com/moment/luxon/pull/468 to improve Luxon CDN setup