### PR TITLE
Don't preclude plugin from being used with Chart.js 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "yargs": "^13.2.1"
   },
   "peerDependencies": {
-    "chart.js": ">= 2.8.0 < 3",
+    "chart.js": ">= 2.8.0",
     "luxon": "^1.0.0"
   }
 }


### PR DESCRIPTION
It looks like the date-fns plugin has the same thing. I'm not quite sure why it was put there

https://github.com/chartjs/chartjs-adapter-date-fns/blob/master/package.json#L32