### PR TITLE
Upgrade to Chart.js 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
-    "chart.js": "^2.8.0",
+    "chart.js": "^3.0.0-alpha",
     "eslint-config-chartjs": "^0.1.0",
     "gulp": "^4.0.0",
     "gulp-eslint": "^5.0.0",
@@ -39,7 +39,7 @@
     "yargs": "^13.2.1"
   },
   "peerDependencies": {
-    "chart.js": ">= 2.8.0 < 3",
+    "chart.js": "^3.0.0-alpha",
     "luxon": "^1.0.0"
   }
 }

--- a/test/specs/luxon-adapter.spec.js
+++ b/test/specs/luxon-adapter.spec.js
@@ -8,16 +8,15 @@ describe('Luxon Adapter', function() {
 			data: {
 				datasets: [{
 					data: [{
-						t: 0,
+						x: 0,
 						y: 100
 					}]
 				}]
 			},
 			options: {
 				scales: {
-					xAxes: [{
+					x: {
 						type: 'time',
-						id: 'xAxis0',
 						time: {
 							unit: 'second',
 							displayFormats: {
@@ -32,12 +31,12 @@ describe('Luxon Adapter', function() {
 						ticks: {
 							source: 'data'
 						}
-					}]
+					}
 				}
 			}
 		});
 
-		expect(chart.scales.xAxis0.ticks[0]).toEqual('Jan 1, 1970, 6:00:00 AM');
+		expect(chart.scales.x.ticks[0].label).toEqual('Jan 1, 1970, 6:00:00 AM');
 	});
 
 	it('should parse Luxon DateTime objects directly', function() {


### PR DESCRIPTION
We probably don't want to merge this yet, but I'm just sharing what will need to happen to make the tests work for 3.x

I'm not sure why I had to change `t` to `x`. Looking at [the docs](https://www.chartjs.org/docs/next/axes/cartesian/time.html#data-sets), it doesn't seem like I should have to do that.