### PR TITLE
Support Chart.js 3's ES6 default export and release 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "chartjs-adapter-luxon",
   "homepage": "https://www.chartjs.org",
-  "description": "Chart.js adapter to use luxon for time functionalities",
-  "version": "0.2.0",
+  "description": "Chart.js adapter to use Luxon for time functionalities",
+  "version": "0.2.1",
   "license": "MIT",
   "main": "dist/chartjs-adapter-luxon.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import { _adapters, helpers } from 'chart.js';
+import Chart from 'chart.js';
 import { DateTime } from 'luxon';
 
-var FORMATS = {
+const FORMATS = {
 	datetime: DateTime.DATETIME_MED_WITH_SECONDS,
 	millisecond: 'h:mm:ss.SSS a',
 	second: DateTime.TIME_WITH_SECONDS,
@@ -14,7 +14,7 @@ var FORMATS = {
 	year: { year: 'numeric' }
 };
 
-_adapters._date.override({
+Chart._adapters._date.override({
 	_id: 'luxon', // DEBUG
 
 	/**
@@ -29,13 +29,13 @@ _adapters._date.override({
 	},
 
 	parse: function(value, format) {
-		var options = this.options;
+		const options = this.options;
 
-		if (helpers.isNullOrUndef(value)) {
+		if (Chart.helpers.isNullOrUndef(value)) {
 			return null;
 		}
 
-		var type = typeof value;
+		const type = typeof value;
 		if (type === 'number') {
 			value = this._create(value);
 		} else if (type === 'string') {
@@ -54,14 +54,14 @@ _adapters._date.override({
 	},
 
 	format: function(time, format) {
-		var datetime = this._create(time);
+		const datetime = this._create(time);
 		return typeof format === 'string'
 			? datetime.toFormat(format, this.options)
 			: datetime.toLocaleString(format);
 	},
 
 	add: function(time, amount, unit) {
-		var args = {};
+		const args = {};
 		args[unit] = amount;
 		return this._create(time).plus(args).valueOf();
 	},


### PR DESCRIPTION
I'm trying Chart.js 3.0.0-alpha out in a webpack project. Webpack compiles the luxon adapter code to `chart_js._adapters._date.override({` , but `chart_js._adapters` is `undefined`

This fix should still work for Chart.js 2 as well

This change allows the library to load for me. It still fails at runtime against a version I'm including via `npm link`, but that's because it finds `chartjs-adapter-luxon/node_modules/chart.js` and tries to use it. So while I haven't been able to thoroughly test this, my expectation is that it would work just fine using a released version since it wouldn't find a second version of Chart.js if grabbing it from npm instead of using the linked version.