### PR TITLE
Update rollup and add ESM output

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "babel-plugin-istanbul": "^6.0.0",
-    "chart.js": "^3.0.0-alpha",
+    "chart.js": "^2.8.0",
     "eslint-config-chartjs": "^0.1.0",
     "gulp": "^4.0.0",
     "gulp-eslint": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "devDependencies": {
     "rollup-plugin-babel": "^4.4.0",
+    "@rollup/plugin-json": "^4.0.2",
     "rollup-plugin-cleanup": "^3.1.1",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
@@ -45,8 +46,5 @@
     "chart.js": ">= 2.8.0 < 3",
     "luxon": "^1.0.0"
   },
-  "dependencies": {
-    "@rollup/plugin-json": "^4.0.2",
-    "rollup-plugin-babel": "^4.4.0"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "version": "0.2.1",
   "license": "MIT",
   "main": "dist/chartjs-adapter-luxon.js",
+  "jsdelivr": "dist/chartjs-adapter-luxon.min.js",
+  "unpkg": "dist/chartjs-adapter-luxon.min.js",
+  "module": "dist/chartjs-adapter-luxon.esm.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/chartjs/chartjs-adapter-luxon.git"

--- a/package.json
+++ b/package.json
@@ -39,8 +39,6 @@
     "karma-spec-reporter": "^0.0.32",
     "luxon": "^1.0.0",
     "rollup": "^2.0.5",
-    "rollup-plugin-babel": "^4.4.0",
-    "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-terser": "^5.3.0",
     "yargs": "^13.2.1"
   },
@@ -48,6 +46,5 @@
     "chart.js": ">= 2.8.0 < 3",
     "luxon": "^1.0.0"
   },
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "dist/*.js"
   ],
   "devDependencies": {
-    "rollup-plugin-babel": "^4.4.0",
-    "@rollup/plugin-json": "^4.0.2",
-    "rollup-plugin-cleanup": "^3.1.1",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
     "babel-plugin-istanbul": "^6.0.0",
@@ -42,6 +39,8 @@
     "karma-spec-reporter": "^0.0.32",
     "luxon": "^1.0.0",
     "rollup": "^2.0.5",
+    "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-cleanup": "^3.1.1",
     "rollup-plugin-terser": "^5.3.0",
     "yargs": "^13.2.1"
   },
@@ -49,5 +48,6 @@
     "chart.js": ">= 2.8.0 < 3",
     "luxon": "^1.0.0"
   },
-  "dependencies": {}
+  "dependencies": {
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
-    "babel-plugin-istanbul": "^6.0.0",
     "chart.js": "^2.8.0",
     "eslint-config-chartjs": "^0.1.0",
     "gulp": "^4.0.0",
@@ -45,6 +44,5 @@
   "peerDependencies": {
     "chart.js": ">= 2.8.0 < 3",
     "luxon": "^1.0.0"
-  },
-  "dependencies": {}
+  }
 }

--- a/package.json
+++ b/package.json
@@ -20,9 +20,12 @@
     "dist/*.js"
   ],
   "devDependencies": {
+    "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-cleanup": "^3.1.1",
     "@rollup/plugin-commonjs": "^11.0.2",
     "@rollup/plugin-node-resolve": "^7.1.1",
-    "chart.js": "^2.8.0",
+    "babel-plugin-istanbul": "^6.0.0",
+    "chart.js": "^3.0.0-alpha",
     "eslint-config-chartjs": "^0.1.0",
     "gulp": "^4.0.0",
     "gulp-eslint": "^5.0.0",
@@ -41,5 +44,9 @@
   "peerDependencies": {
     "chart.js": ">= 2.8.0 < 3",
     "luxon": "^1.0.0"
+  },
+  "dependencies": {
+    "@rollup/plugin-json": "^4.0.2",
+    "rollup-plugin-babel": "^4.4.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -72,8 +72,8 @@ module.exports = [
 	},
 
 	// ES6 builds
-	// dist/Chart.esm.min.js
-	// dist/Chart.esm.js
+	// dist/chartjs-adapter-luxon.esm.js
+	// dist/chartjs-adapter-luxon.esm.min.js
 	{
 		input,
 		plugins: [
@@ -108,7 +108,7 @@ module.exports = [
 			})
 		],
 		output: {
-			file: 'dist/${pkg.name}.esm.min.js',
+			file: `dist/${pkg.name}.esm.min.js`,
 			format: 'esm',
 			indent: false,
 		},

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -79,7 +79,7 @@ module.exports = [
 		plugins: [
 			json(),
 			resolve(),
-			babel({envName: 'es6'}),
+			babel({ envName: 'es6' }),
 			cleanup({
 				sourcemap: true
 			})
@@ -100,7 +100,7 @@ module.exports = [
 		plugins: [
 			json(),
 			resolve(),
-			babel({envName: 'es6'}),
+			babel({ envName: 'es6' }),
 			terser({
 				output: {
 					preamble: banner

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,8 +4,6 @@
 
 const babel = require('rollup-plugin-babel');
 const cleanup = require('rollup-plugin-cleanup');
-const json = require('@rollup/plugin-json');
-const resolve = require('@rollup/plugin-node-resolve');
 const terser = require('rollup-plugin-terser').terser;
 const pkg = require('./package.json');
 
@@ -21,14 +19,6 @@ const input = 'src/index.js';
 module.exports = [
 	{
 		input,
-		plugins: [
-			json(),
-			resolve(),
-			babel(),
-			cleanup({
-				sourcemap: true
-			})
-		],
 		output: {
 			file: `dist/${pkg.name}.js`,
 			banner: banner,
@@ -47,9 +37,6 @@ module.exports = [
 	{
 		input,
 		plugins: [
-			json(),
-			resolve(),
-			babel(),
 			terser({
 				output: {
 					preamble: banner
@@ -77,8 +64,6 @@ module.exports = [
 	{
 		input,
 		plugins: [
-			json(),
-			resolve(),
 			babel({ envName: 'es6' }),
 			cleanup({
 				sourcemap: true
@@ -98,8 +83,6 @@ module.exports = [
 	{
 		input,
 		plugins: [
-			json(),
-			resolve(),
 			babel({ envName: 'es6' }),
 			terser({
 				output: {
@@ -110,7 +93,7 @@ module.exports = [
 		output: {
 			file: `dist/${pkg.name}.esm.min.js`,
 			format: 'esm',
-			indent: false,
+			indent: false
 		},
 		external: [
 			'chart.js',

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,6 @@
 /* eslint-disable import/no-commonjs */
 /* eslint-env es6 */
 
-
-const babel = require('rollup-plugin-babel');
-const cleanup = require('rollup-plugin-cleanup');
 const terser = require('rollup-plugin-terser').terser;
 const pkg = require('./package.json');
 
@@ -63,12 +60,6 @@ module.exports = [
 	// dist/chartjs-adapter-luxon.esm.min.js
 	{
 		input,
-		plugins: [
-			babel({ envName: 'es6' }),
-			cleanup({
-				sourcemap: true
-			})
-		],
 		output: {
 			file: `dist/${pkg.name}.esm.js`,
 			banner,
@@ -83,7 +74,6 @@ module.exports = [
 	{
 		input,
 		plugins: [
-			babel({ envName: 'es6' }),
 			terser({
 				output: {
 					preamble: banner

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,11 @@
+/* eslint-disable import/no-commonjs */
+/* eslint-env es6 */
+
+
+const babel = require('rollup-plugin-babel');
+const cleanup = require('rollup-plugin-cleanup');
+const json = require('@rollup/plugin-json');
+const resolve = require('@rollup/plugin-node-resolve');
 const terser = require('rollup-plugin-terser').terser;
 const pkg = require('./package.json');
 
@@ -8,9 +16,19 @@ const banner = `/*!
  * Released under the ${pkg.license} license
  */`;
 
+const input = 'src/index.js';
+
 module.exports = [
 	{
-		input: 'src/index.js',
+		input,
+		plugins: [
+			json(),
+			resolve(),
+			babel(),
+			cleanup({
+				sourcemap: true
+			})
+		],
 		output: {
 			file: `dist/${pkg.name}.js`,
 			banner: banner,
@@ -27,7 +45,17 @@ module.exports = [
 		]
 	},
 	{
-		input: 'src/index.js',
+		input,
+		plugins: [
+			json(),
+			resolve(),
+			babel(),
+			terser({
+				output: {
+					preamble: banner
+				}
+			})
+		],
 		output: {
 			file: `dist/${pkg.name}.min.js`,
 			format: 'umd',
@@ -37,16 +65,56 @@ module.exports = [
 				luxon: 'luxon'
 			}
 		},
+		external: [
+			'chart.js',
+			'luxon'
+		]
+	},
+
+	// ES6 builds
+	// dist/Chart.esm.min.js
+	// dist/Chart.esm.js
+	{
+		input,
 		plugins: [
+			json(),
+			resolve(),
+			babel({envName: 'es6'}),
+			cleanup({
+				sourcemap: true
+			})
+		],
+		output: {
+			file: `dist/${pkg.name}.esm.js`,
+			banner,
+			format: 'esm',
+			indent: false,
+		},
+		external: [
+			'chart.js',
+			'luxon'
+		]
+	},
+	{
+		input,
+		plugins: [
+			json(),
+			resolve(),
+			babel({envName: 'es6'}),
 			terser({
 				output: {
 					preamble: banner
 				}
 			})
 		],
+		output: {
+			file: 'dist/${pkg.name}.esm.min.js',
+			format: 'esm',
+			indent: false,
+		},
 		external: [
 			'chart.js',
 			'luxon'
 		]
-	}
+	},
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,3 @@
-/* eslint-disable import/no-commonjs */
-/* eslint-env es6 */
-
 const terser = require('rollup-plugin-terser').terser;
 const pkg = require('./package.json');
 
@@ -54,10 +51,6 @@ module.exports = [
 			'luxon'
 		]
 	},
-
-	// ES6 builds
-	// dist/chartjs-adapter-luxon.esm.js
-	// dist/chartjs-adapter-luxon.esm.min.js
 	{
 		input,
 		output: {
@@ -89,5 +82,5 @@ module.exports = [
 			'chart.js',
 			'luxon'
 		]
-	},
+	}
 ];


### PR DESCRIPTION
This updates the rollup config to have some parity with the updated chart.js rollup config, and also adds ESM output.

A unit test needs to be updated, but a fix is available already in #12 
~This also updates the chartjs version like #12~

~depends on #12~
closes #16 