### PR TITLE
Fix parsing of JS Date objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ Chart._adapters._date.override({
       value = DateTime.fromJSDate(value, options);
     } else if (type === 'object' && !(value instanceof DateTime)) {
       value = DateTime.fromObject(value);
-    } 
+    }
 
     return value.isValid ? value.valueOf() : null;
   },

--- a/src/index.js
+++ b/src/index.js
@@ -44,11 +44,11 @@ Chart._adapters._date.override({
       } else {
         value = DateTime.fromISO(value, options);
       }
-    } else if (type === 'object' && !(value instanceof DateTime)) {
-      value = DateTime.fromObject(value);
     } else if (value instanceof Date) {
       value = DateTime.fromJSDate(value, options);
-    }
+    } else if (type === 'object' && !(value instanceof DateTime)) {
+      value = DateTime.fromObject(value);
+    } 
 
     return value.isValid ? value.valueOf() : null;
   },

--- a/test/specs/luxon-adapter.spec.js
+++ b/test/specs/luxon-adapter.spec.js
@@ -45,6 +45,12 @@ describe('Luxon Adapter', function() {
     expect(adapter.parse(DateTime.fromISO('1970-01-01T00:00:01Z'))).toEqual(1000);
   });
 
+  it('should parse Luxon Date objects directly', function() {
+    var adapter = new Chart._adapters._date();
+
+    expect(adapter.parse(new Date(0))).toEqual(0);
+  });
+
   it('should format correctly using format presets', function() {
     var adapter = new Chart._adapters._date({zone: 'UTC'});
     var formats = adapter.formats();


### PR DESCRIPTION
The if conditions were in the wrong order so we tried to parse JS `Date` objects as Luxon `DateTime` objects leading to incorrect results.

```javascript
const x = new Date();
typeof x // "object"
```