### PR TITLE
Fix isoweek startOf returning incorrect date for the first day of the week.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ _adapters._date.override({
     if (unit === 'isoWeek') {
       weekday = Math.trunc(Math.min(Math.max(0, weekday), 6));
       const dateTime = this._create(time);
-      return dateTime.minus({days: (dateTime.weekday < weekday ? 7 : 0) + dateTime.weekday - weekday}).startOf('day').valueOf();
+      return dateTime.minus({days: (dateTime.weekday % 7) - weekday}).startOf('day').valueOf();
     }
     return unit ? this._create(time).startOf(unit).valueOf() : time;
   },

--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ _adapters._date.override({
     if (unit === 'isoWeek') {
       weekday = Math.trunc(Math.min(Math.max(0, weekday), 6));
       const dateTime = this._create(time);
-      return dateTime.minus({days: (dateTime.weekday % 7) - weekday}).startOf('day').valueOf();
+      return dateTime.minus({days: (dateTime.weekday - weekday + 7) % 7}).startOf('day').valueOf();
     }
     return unit ? this._create(time).startOf(unit).valueOf() : time;
   },

--- a/test/specs/luxon-adapter.spec.js
+++ b/test/specs/luxon-adapter.spec.js
@@ -111,4 +111,16 @@ describe('Luxon Adapter', function() {
     }
 
   });
+
+  it('should use correct date for startOf isoWeek when date is beginning of week', function() {
+    const adapter = new Chart._adapters._date();
+    const daysInMonth = DateTime.local().daysInMonth;
+
+    for (let dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
+      const dt = DateTime.fromObject({day: dayOfMonth, hour: 8, minute: 30});
+      const dayOfWeek = dt.weekday % 7;
+      const startOf = adapter.startOf(dt.valueOf(), 'isoWeek', dayOfWeek);
+      expect(adapter.format(startOf, 'D')).toEqual(dt.toFormat('D'));
+    }
+  });
 });

--- a/test/specs/luxon-adapter.spec.js
+++ b/test/specs/luxon-adapter.spec.js
@@ -78,7 +78,7 @@ describe('Luxon Adapter', function() {
         const dt = DateTime.fromObject({day: dayOfMonth, hour: 8, minute: 30});
         const startOf = adapter.startOf(dt.valueOf(), 'isoWeek', dayOfWeekNames.indexOf(dayOfWeek));
         expect(adapter.format(startOf, 'ccc')).toEqual(dayOfWeek);
-        expect(startOf.day).not.toBeGreaterThan(dt.day);
+        expect(DateTime.fromMillis(startOf)).toBeLessThanOrEqual(dt);
       }
     }
 
@@ -86,28 +86,28 @@ describe('Luxon Adapter', function() {
       const dt = DateTime.fromObject({day: dayOfMonth, hour: 8, minute: 30});
       const startOf = adapter.startOf(dt.valueOf(), 'isoWeek', false);
       expect(adapter.format(startOf, 'ccc')).toEqual('Sun');
-      expect(startOf.day).not.toBeGreaterThan(dt.day);
+      expect(DateTime.fromMillis(startOf)).toBeLessThanOrEqual(dt);
     }
 
     for (let dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
       const dt = DateTime.fromObject({day: dayOfMonth, hour: 8, minute: 30});
       const startOf = adapter.startOf(dt.valueOf(), 'isoWeek', true);
       expect(adapter.format(startOf, 'ccc')).toEqual('Mon');
-      expect(startOf.day).not.toBeGreaterThan(dt.day);
+      expect(DateTime.fromMillis(startOf)).toBeLessThanOrEqual(dt);
     }
 
     for (let dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
       const dt = DateTime.fromObject({day: dayOfMonth, hour: 8, minute: 30});
       const startOf = adapter.startOf(dt.valueOf(), 'isoWeek', 100);
       expect(adapter.format(startOf, 'ccc')).toEqual('Sat');
-      expect(startOf.day).not.toBeGreaterThan(dt.day);
+      expect(DateTime.fromMillis(startOf)).toBeLessThanOrEqual(dt);
     }
 
     for (let dayOfMonth = 1; dayOfMonth <= daysInMonth; dayOfMonth++) {
       const dt = DateTime.fromObject({day: dayOfMonth, hour: 8, minute: 30});
       const startOf = adapter.startOf(dt.valueOf(), 'isoWeek', -100);
       expect(adapter.format(startOf, 'ccc')).toEqual('Sun');
-      expect(startOf.day).not.toBeGreaterThan(dt.day);
+      expect(DateTime.fromMillis(startOf)).toBeLessThanOrEqual(dt);
     }
 
   });


### PR DESCRIPTION
This PR fixes an issue causing days that land on the isoweek day to round down to the _previous_ week.

I've added a spec that fails with the previous code.