### PR TITLE
Improve the use of the custom options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,7 +47,7 @@ _adapters._date.override({
     } else if (value instanceof Date) {
       value = DateTime.fromJSDate(value, options);
     } else if (type === 'object' && !(value instanceof DateTime)) {
-      value = DateTime.fromObject(value);
+      value = DateTime.fromObject(value, options);
     }
 
     return value.isValid ? value.valueOf() : null;
@@ -56,7 +56,7 @@ _adapters._date.override({
   format: function(time, format) {
     const datetime = this._create(time);
     return typeof format === 'string'
-      ? datetime.toFormat(format, this.options)
+      ? datetime.toFormat(format)
       : datetime.toLocaleString(format);
   },
 


### PR DESCRIPTION
This PR is:

1. adding the options to `parse` function when `DateTime` is created by an object (was missing) in order to have a `DateTime` configured with user options
2. removing the options from `toFormat` method of Luxon because `DateTime` is always created with the options (see `_create` function)