### PR TITLE
Improve typeof invocation when parsing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -31,11 +31,11 @@ _adapters._date.override({
   parse: function(value, format) {
     const options = this.options;
 
-    if (value === null || typeof value === 'undefined') {
+    const type = typeof value;
+    if (value === null || type === 'undefined') {
       return null;
     }
 
-    const type = typeof value;
     if (type === 'number') {
       value = this._create(value);
     } else if (type === 'string') {


### PR DESCRIPTION
The `typeof` was invoked twice in the parse method, to check if undefined (in `if` statement) and later to get the type.
Moved before consistency check in order to invoke only one when the `value` argument is not `null`.