### PR TITLE
Update Development section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ You first need to install node dependencies (requires [Node.js](https://nodejs.o
 The following commands will then be available from the repository root:
 
 ```
-> gulp build            // build dist files
-> gulp build --watch    // build and watch for changes
-> gulp lint             // perform code linting
+> npm run build         // build dist files
+> npm test              // perfom code testing
+> npm run lint          // perform code linting
 ```
 
 ## License


### PR DESCRIPTION
README was containing teh develpment section referring `gulp`, not used anymore.