### PR TITLE
re-add main key to package.json to allow eslint to resolve module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "jsdelivr": "dist/chartjs-adapter-luxon.umd.min.js",
   "unpkg": "dist/chartjs-adapter-luxon.umd.min.js",
+  "main": "dist/chartjs-adapter-luxon.esm.min.js",
   "exports": {
     ".": "./dist/chartjs-adapter-luxon.esm.js"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "jsdelivr": "dist/chartjs-adapter-luxon.umd.min.js",
   "unpkg": "dist/chartjs-adapter-luxon.umd.min.js",
-  "main": "dist/chartjs-adapter-luxon.esm.min.js",
+  "main": "dist/chartjs-adapter-luxon.esm.js",
   "exports": {
     ".": "./dist/chartjs-adapter-luxon.esm.js"
   },


### PR DESCRIPTION
Thanks for the library!

In #79, the [main key was removed](https://github.com/chartjs/chartjs-adapter-luxon/pull/79/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7) from the package.json.  This causes the eslint [import plugin](https://github.com/import-js/eslint-plugin-import/blob/v2.26.0/README.md) to fail.

Re-adding the `main` key resolves the issue.